### PR TITLE
fix: plugin not loading for obs 28

### DIFF
--- a/com.obsproject.Studio.Plugin.TransitionTable.yaml
+++ b/com.obsproject.Studio.Plugin.TransitionTable.yaml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.TransitionTable
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//5.15-21.08
+sdk: org.kde.Sdk//6.3
 build-extension: true
 separate-locales: false
 appstream-compose: false


### PR DESCRIPTION
In obs 28 the plugins is not loading:

```
error: os_dlopen(/app/plugins/lib/obs-plugins/transition-table.so->/app/plugins/lib/obs-plugins/transition-table.so): libQt5Widgets.so.5: Ne peut ouvrir le fichier d'objet partagé: Aucun fichier ou dossier de ce type
```

Update the sdk to make it works.

```
info: [Transition Table] loaded version 0.2.5
```