### PR TITLE
Update KDE SDK to 6.6 and disable automerge-flathubbot-prs

### DIFF
--- a/com.obsproject.Studio.Plugin.TransitionTable.yaml
+++ b/com.obsproject.Studio.Plugin.TransitionTable.yaml
@@ -2,7 +2,7 @@ id: com.obsproject.Studio.Plugin.TransitionTable
 branch: stable
 runtime: com.obsproject.Studio
 runtime-version: stable
-sdk: org.kde.Sdk//6.5
+sdk: org.kde.Sdk//6.6
 build-extension: true
 separate-locales: false
 appstream-compose: false

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
     "skip-icons-check": true,
-    "only-arches": ["x86_64"],
-    "automerge-flathubbot-prs": true
+    "only-arches": ["x86_64"]
   }


### PR DESCRIPTION
Recent update to the OBS flatpak broke multiple plugins. Rebuilding with the latest KDE SDK should fix this issue.